### PR TITLE
Update InstallStart.java

### DIFF
--- a/src/com/android/packageinstaller/InstallStart.java
+++ b/src/com/android/packageinstaller/InstallStart.java
@@ -126,6 +126,7 @@ public class InstallStart extends Activity {
         }
 
         if (nextActivity != null) {
+            nextActivity.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             startActivity(nextActivity);
         }
         finish();


### PR DESCRIPTION
Add grant uri permission flag
When the application requests to install multiple applications at the same time, multiple current activities are started accordingly.
The framework may call the onCreate()  of multiple current activity instances when starting so many activity instances. 
Call finish() now, the uri permission of the temporary request will be cleared.
After InstallStaging does not get permission, it will cause a SecurityException.